### PR TITLE
Add is_deleted to videos PUT NEON-951

### DIFF
--- a/cmsapiv2.json
+++ b/cmsapiv2.json
@@ -1354,6 +1354,13 @@
                         "description": "Should testing be enabled?",
                         "required": false,
                         "type": "boolean"
+                    },
+                    {
+                        "name": "is_deleted",
+                        "in": "query",
+                        "description": "Set the video as deleted, removing it from in normal search results",
+                        "required": false,
+                        "type": "boolean"
                     }
                 ],
                 "responses": {

--- a/cmsapiv2.json
+++ b/cmsapiv2.json
@@ -1356,9 +1356,9 @@
                         "type": "boolean"
                     },
                     {
-                        "name": "is_deleted",
+                        "name": "hidden",
                         "in": "query",
-                        "description": "Set the video as deleted, removing it from in normal search results",
+                        "description": "Set the video as hidden, removing it in normal search results",
                         "required": false,
                         "type": "boolean"
                     }


### PR DESCRIPTION
Allow client to set is_deleted in PUT to videos endpoint. This removes it from external search results.

https://neonlabs.atlassian.net/browse/NEON-951
